### PR TITLE
簡易的なレスポンシブ対応を実施

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,96 +1,148 @@
 <!DOCTYPE html>
 <html lang="ja">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Preflop Trainer</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" href="style.css" />
+    </head>
 
-<head>
-    <meta charset="UTF-8" />
-    <title>Preflop Trainer</title>
-    <link rel="stylesheet" href="style.css" />
-</head>
-
-<body>
-    <div class="header">
-        <h1 style="padding-left: 3%;">Poker Preflop Trainer</h1>
-    </div>
-
-    <div class="main-content">
-        <div id="left-pane" class="left-pane" style="width: calc(30% - 7px)">
-
-            <div id="aim-container" style="padding: 0 3%;">
-                <h2 id="aim">Open raise レンジの練習</h2>
-                <p class="explanation">Preflop のレンジを覚えて、周りの人間をクラッシュしよう！</p>
-                <h3>Open raise レンジの原則</h3>
-                <p class="explanation">Preflop で他のプレイヤーが raise していない状態で最初に raise することを、<strong>open raise</strong> もしくは単に <strong>open する</strong> 
-                    と呼びます。</p>
-                <p class="explanation">Open raise レンジは、自分の後ろに座っているプレイヤーの人数によって決まります。
-                    自分の後ろに多くのプレイヤーがいるほど、参加するハンドは絞る必要があります。</p>
-                <div id="seats-image-container">
-                    <h3>ポジションの名前の一覧</h3>
-                    <p>9人卓の場合、preflop でアクションをする順に、UTG, UTG+1, UTG+2, LJ, HJ, CO, BTN, SB, BB と呼ばれます。</p>
-
-                    <img src="images/seats_name.png" alt="seats" width="100%">
-                    <ul>
-                        <li>UTG: Under the Gun (アンダーザガン)</li>
-                        <li>UTG+1: Under the Gun+1 (プラス1)</li>
-                        <li>UTG+2: Under the Gun+2 (プラス2)</li>
-                        <li>LJ: Low Jack (ロージャック)</li>
-                        <li>HJ: High Jack (ハイジャック)</li>
-                        <li>CO: Cut Off (カットオフ)</li>
-                        <li>BTN: Button (ボタン)</li>
-                        <li>SB: Small Blind (スモールブラインド)</li>
-                        <li>BB: Big Blind (ビッグブラインド)</li>
-                    </ul>
-                </div>
-                <p class="explanation detailExplanation">この Trainer は、<a
-                        href="https://app.gtowizard.com/solutions?solution_type=gwiz&gmfs_solution_tab=ai_sols&gametype=Cash9m50zGeneral&depth=100&gmfft_sort_key=0&gmfft_sort_order=desc&history_spot=0&preflop_actions=">GTO
-                        Wizard Cash, 9max, 100bb, General, NL50, open:
-                        2.5x, 3b: GTO</a>
-                    のソリューションをもとに作成されています。 </p>
-            </div>
-
+    <body>
+        <div class="header">
+            <h1 style="padding-left: 3%">Poker Preflop Trainer</h1>
         </div>
 
-        <div id="gutter" class="gutter" style="width: 14px; height: 100%;"></div>
+        <div class="main-content">
+            <div id="left-pane" class="left-pane">
+                <div id="aim-container" style="padding: 0 3%">
+                    <h2 id="aim">Open raise レンジの練習</h2>
+                    <p class="explanation">
+                        Preflop のレンジを覚えて、周りの人間をクラッシュしよう！
+                    </p>
+                    <h3>Open raise レンジの原則</h3>
+                    <p class="explanation">
+                        Preflop で他のプレイヤーが raise していない状態で最初に
+                        raise することを、<strong>open raise</strong>
+                        もしくは単に <strong>open する</strong> と呼びます。
+                    </p>
+                    <p class="explanation">
+                        Open raise
+                        レンジは、自分の後ろに座っているプレイヤーの人数によって決まります。
+                        自分の後ろに多くのプレイヤーがいるほど、参加するハンドは絞る必要があります。
+                    </p>
+                    <div id="seats-image-container">
+                        <h3>ポジションの名前の一覧</h3>
+                        <p>
+                            9人卓の場合、preflop でアクションをする順に、UTG,
+                            UTG+1, UTG+2, LJ, HJ, CO, BTN, SB, BB と呼ばれます。
+                        </p>
 
-        <div id="right-pane" class="right-pane" style="width: calc(70% - 7px);">
-
-            <div class="question">
-                <p style="text-align: right;">現在 <strong><span id="successive-correct-answer"></span> 問</strong>連続正解中！(累計正解数：<span id="correct-num"></span>/<span id="question-num"></span>問中)</p>
-                <p>このハンドは open raise できますか？</p>
-                <p>あなたのポジション：<strong><span id="position" style="font-size:2em;"></span></strong> （<span
-                        id="restPlayersNum"></span>人のプレイヤーが後ろにいます）</p> <!-- ここにプレイヤーのポジションが表示される。 -->
-                <p><span id=""></span></p>
-            </div>
-
-            <div id="hero-hand-container">
-                <div class="hero-card-container">
-                    <img id="image1" class="overlay-image" src="images/cards/2c.png" alt="ランダムなカード1枚目">
-                    <img id="background1" class="base-image" src="images/cards/background.png" alt="ランダムなカード1枚目">
+                        <img
+                            src="images/seats_name.png"
+                            alt="seats"
+                            width="100%"
+                        />
+                        <ul>
+                            <li>UTG: Under the Gun (アンダーザガン)</li>
+                            <li>UTG+1: Under the Gun+1 (プラス1)</li>
+                            <li>UTG+2: Under the Gun+2 (プラス2)</li>
+                            <li>LJ: Low Jack (ロージャック)</li>
+                            <li>HJ: High Jack (ハイジャック)</li>
+                            <li>CO: Cut Off (カットオフ)</li>
+                            <li>BTN: Button (ボタン)</li>
+                            <li>SB: Small Blind (スモールブラインド)</li>
+                            <li>BB: Big Blind (ビッグブラインド)</li>
+                        </ul>
+                    </div>
+                    <p class="explanation detailExplanation">
+                        この Trainer は、<a
+                            href="https://app.gtowizard.com/solutions?solution_type=gwiz&gmfs_solution_tab=ai_sols&gametype=Cash9m50zGeneral&depth=100&gmfft_sort_key=0&gmfft_sort_order=desc&history_spot=0&preflop_actions="
+                            >GTO Wizard Cash, 9max, 100bb, General, NL50, open:
+                            2.5x, 3b: GTO</a
+                        >
+                        のソリューションをもとに作成されています。
+                    </p>
                 </div>
-                <div class="hero-card-container">
-                    <img id="image2" class="overlay-image" src="images/cards/2d.png" alt="ランダムなカード2枚目">
-                    <img id="background2" class="base-image" src="images/cards/background.png" alt="ランダムなカード2枚目">
+            </div>
+
+            <div id="gutter" class="gutter"></div>
+
+            <div id="right-pane" class="right-pane">
+                <div class="question">
+                    <p style="text-align: right">
+                        現在
+                        <strong
+                            ><span id="successive-correct-answer"></span>
+                            問</strong
+                        >連続正解中！(累計正解数：<span id="correct-num"></span
+                        >/<span id="question-num"></span>問中)
+                    </p>
+                    <p>このハンドは open raise できますか？</p>
+                    <p>
+                        あなたのポジション：<strong
+                            ><span id="position" style="font-size: 2em"></span
+                        ></strong>
+                        （<span id="restPlayersNum"></span
+                        >人のプレイヤーが後ろにいます）
+                    </p>
+                    <!-- ここにプレイヤーのポジションが表示される。 -->
+                    <p><span id=""></span></p>
+                </div>
+
+                <div id="hero-hand-container">
+                    <div class="hero-card-container">
+                        <img
+                            id="image1"
+                            class="overlay-image"
+                            src="images/cards/2c.png"
+                            alt="ランダムなカード1枚目"
+                        />
+                        <img
+                            id="background1"
+                            class="base-image"
+                            src="images/cards/background.png"
+                            alt="ランダムなカード1枚目"
+                        />
+                    </div>
+                    <div class="hero-card-container">
+                        <img
+                            id="image2"
+                            class="overlay-image"
+                            src="images/cards/2d.png"
+                            alt="ランダムなカード2枚目"
+                        />
+                        <img
+                            id="background2"
+                            class="base-image"
+                            src="images/cards/background.png"
+                            alt="ランダムなカード2枚目"
+                        />
+                    </div>
+                </div>
+
+                <div id="actionButton-container">
+                    <button id="foldButton" class="actionButton">
+                        Fold (F)
+                    </button>
+                    <button id="callButton" class="actionButton">
+                        Call (C)
+                    </button>
+                    <button id="raiseButton" class="actionButton">
+                        Raise (R)
+                    </button>
+                </div>
+
+                <!-- 解答が入力されてから表示 -->
+                <div id="answer-container" class="question"></div>
+                <div id="frequency-container" class="question"></div>
+                <div id="nextButton-container">
+                    <button id="nextButton" class="nextButton">
+                        Next Hand (⏎)
+                    </button>
                 </div>
             </div>
-
-            <div id="actionButton-container">
-                <button id="foldButton" class="actionButton">Fold (F)</button>
-                <button id="callButton" class="actionButton">Call (C)</button>
-                <button id="raiseButton" class="actionButton">Raise (R)</button>
-            </div>
-
-            <!-- 解答が入力されてから表示 -->
-            <div id="answer-container" class="question"></div>
-            <div id="frequency-container" class="question"></div>
-            <div id="nextButton-container">
-                <button id="nextButton" class="nextButton">Next Hand (⏎)</button>
-            </div>
-
         </div>
 
-    </div>
-
-
-    <script src="script.js"></script>
-</body>
-
+        <script src="script.js"></script>
+    </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,39 +1,43 @@
 :root {
-    --raise-button-color: #F03C3C;
+    --raise-button-color: #f03c3c;
     --call-button-color: #5ab966;
-    --fold-button-color: #3D7CB8;
-    --seekerstart-color: #F2ba22;
+    --fold-button-color: #3d7cb8;
+    --seekerstart-color: #f2ba22;
+}
+
+* {
+    margin: 0;
+    padding: 0;
 }
 
 .header {
     /* background-color: var(--seekerstart-color); */
-    background: linear-gradient(to right, var(--seekerstart-color), #c9cbca); 
+    background: linear-gradient(to right, var(--seekerstart-color), #c9cbca);
     color: black;
     font-style: italic;
-    position: absolute;
     top: 0%;
     left: 0%;
     width: 100%;
     height: 5em;
+    line-height: 5em;
 }
 
 .main-content {
-    position: fixed;
-    top: 5em;
-    bottom: 0%;
+    display: flex;
 }
 
 .left-pane {
-    float: left;
     display: block;
+    width: calc(30% - 7px);
     height: 100%;
+    margin: 20px 8px 8px 8px;
     box-sizing: border-box;
     overflow-y: scroll;
     transform: translateZ(0);
 }
 
 .explanation {
-    width: 90%; 
+    width: 90%;
     align-items: center;
 }
 
@@ -42,19 +46,18 @@
 }
 
 .right-pane {
-    float: left;
     display: block;
+    width: calc(70% - 7px);
     height: 100%;
     box-sizing: border-box;
     overflow-y: scroll;
     transform: translateZ(0);
 }
 
-.gutter{
+.gutter {
     display: block;
     box-sizing: border-box;
-    float: left;
-    height: 100%;
+    width: 14px;
     /* cursor: ew-resize; */
     background-image: url("images/gutter.png");
     background-color: #eee;
@@ -70,7 +73,7 @@
     width: 100%;
 }
 
-.question{
+.question {
     font-size: 20px;
     margin: 20px 2em;
 }
@@ -79,7 +82,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    margin: 3em auto ;
+    margin: 3em auto;
 }
 
 .hero-card-container {
@@ -89,7 +92,8 @@
     /* background-color: magenta; */
 }
 
-.overlay-image, .base-image {
+.overlay-image,
+.base-image {
     position: absolute;
     top: 0;
     left: 0;
@@ -112,7 +116,7 @@
     margin: 0 auto;
 }
 
-.nextButton{
+.nextButton {
     /* background-color: #4CAF50; Green */
     background-color: white;
     border: 3px solid black;
@@ -133,7 +137,7 @@
     margin: 0 auto;
 }
 
-.actionButton{
+.actionButton {
     border: none;
     color: white;
     /* padding: 15px 32px; */
@@ -147,12 +151,27 @@
     cursor: pointer;
 }
 
-#raiseButton{
+#raiseButton {
     background-color: var(--raise-button-color);
 }
-#callButton{
+#callButton {
     background-color: var(--call-button-color);
 }
-#foldButton{
+#foldButton {
     background-color: var(--fold-button-color);
+}
+
+@media screen and (max-width: 768px) {
+    .main-content {
+        flex-direction: column-reverse;
+    }
+    .right-pane {
+        width: 100%;
+    }
+    .left-pane {
+        width: 100%;
+    }
+    .gutter {
+        display: none;
+    }
 }


### PR DESCRIPTION
現状画面の大きさに関わらず常に左側にはポーカーの用語解説の部分、右側には問題の部分を表示しているが、このままだとスマホなどの画面が小さい端末で閲覧した場合に見にくい（特に用語解説の部分）ので画面の幅が768px以下の場合は上に問題の部分、その下に用語解説の部分を表示するように変更しました。

- [x] UIの変更
- [ ] ロジックの変更
- [ ] テストの追加

<video width="500px" src="https://github.com/user-attachments/assets/2cbcefae-cffa-4a24-83d8-42223ce84da3" />